### PR TITLE
Multi network support

### DIFF
--- a/src/XRPL.NET/XRPL.NET/Configs/XrplClientConfig.cs
+++ b/src/XRPL.NET/XRPL.NET/Configs/XrplClientConfig.cs
@@ -8,11 +8,11 @@ public class XrplClientConfig
 
     public Dictionary<string, XrplClientNetworkConfig>? Networks { get; set; }
 
-    public string? GetNetworkUrl(string networkKey, XrplProtocol protocol)
+    public string? GetNetworkUrl(int networkId, XrplProtocol protocol)
     {
         string? url = null;
 
-        if (Networks?.TryGetValue(networkKey, out var networkConfig) ?? false)
+        if (Networks?.TryGetValue(networkId.ToString(), out var networkConfig) ?? false)
         {
             url = protocol switch
             {

--- a/src/XRPL.NET/XRPL.NET/Configs/XrplClientConfig.cs
+++ b/src/XRPL.NET/XRPL.NET/Configs/XrplClientConfig.cs
@@ -1,12 +1,27 @@
-﻿namespace XRPL.NET.Configs;
+﻿using XRPL.NET.Enums;
+
+namespace XRPL.NET.Configs;
 
 public class XrplClientConfig
 {
     public const string SectionKey = "XrplClient";
 
-    public string? WebSocketUrl { get; set; }
-    public string? JsonRpcUrl { get; set; }
+    public Dictionary<string, XrplClientNetworkConfig>? Networks { get; set; }
 
-    public Uri WebSocketUri => !string.IsNullOrWhiteSpace(WebSocketUrl) ? new Uri(WebSocketUrl) : throw new ArgumentException($"Missing {nameof(WebSocketUrl)} in the {SectionKey} section");
-    public Uri JsonRpcUri => !string.IsNullOrWhiteSpace(JsonRpcUrl) ? new Uri(JsonRpcUrl) : throw new ArgumentException($"Missing {nameof(JsonRpcUrl)} in the {SectionKey} section");
+    public string? GetNetworkUrl(string networkKey, XrplProtocol protocol)
+    {
+        string? url = null;
+
+        if (Networks?.TryGetValue(networkKey, out var networkConfig) ?? false)
+        {
+            url = protocol switch
+            {
+                XrplProtocol.JsonRpc => networkConfig.JsonRpcUrl,
+                XrplProtocol.WebSocket => networkConfig.WebSocketUrl,
+                _ => throw new ArgumentOutOfRangeException(nameof(protocol), protocol, $"Unknown XRPL protocol: {protocol}")
+            };
+        }
+
+        return url;
+    }
 }

--- a/src/XRPL.NET/XRPL.NET/Configs/XrplClientNetworkConfig.cs
+++ b/src/XRPL.NET/XRPL.NET/Configs/XrplClientNetworkConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace XRPL.NET.Configs;
+
+public class XrplClientNetworkConfig
+{
+    public string? WebSocketUrl { get; set; }
+    public string? JsonRpcUrl { get; set; }
+}

--- a/src/XRPL.NET/XRPL.NET/IXrplClient.cs
+++ b/src/XRPL.NET/XRPL.NET/IXrplClient.cs
@@ -1,6 +1,6 @@
-﻿using XRPL.NET.Enums;
-using XRPL.NET.EventArgs;
+﻿using XRPL.NET.EventArgs;
 using XRPL.NET.Exceptions;
+using XRPL.NET.Models;
 using XRPL.NET.Models.Methods.Accounts;
 using XRPL.NET.Models.Methods.Ledger;
 using XRPL.NET.Models.Methods.ServerInfo;
@@ -18,7 +18,7 @@ public interface IXrplClient : IDisposable
     /// <exception cref="InvalidParametersException">One or more fields are specified incorrectly, or one or more required fields are missing.</exception>
     /// <exception cref="AccountNotFoundException">The address specified in the account field of the request does not correspond to an account in the ledger.</exception>
     /// <exception cref="LedgerNotFoundException">The ledger specified by the ledger_hash or ledger_index does not exist, or it does exist but the server does not have it.</exception>
-    Task<AccountInfoResponse> GetAccountInfo(XrplProtocol protocol, AccountInfoRequest request, CancellationToken token);
+    Task<AccountInfoResponse> GetAccountInfo(XrplNetworkSettings networkSettings, AccountInfoRequest request, CancellationToken token);
 
     /// <summary>
     /// The account_lines method returns information about an account's trust lines, including balances in all non-XRP currencies and assets. All information retrieved is relative to a particular version of the ledger.
@@ -29,7 +29,7 @@ public interface IXrplClient : IDisposable
     /// <exception cref="AccountNotFoundException">The address specified in the account field of the request does not correspond to an account in the ledger.</exception>
     /// <exception cref="LedgerNotFoundException">The ledger specified by the ledger_hash or ledger_index does not exist, or it does exist but the server does not have it.</exception>
     /// <exception cref="AccountMarkerMalformedException">If the marker field provided is not acceptable.</exception>
-    Task<AccountLinesResponse> GetAccountLines(XrplProtocol protocol, AccountLinesRequest request, CancellationToken token);
+    Task<AccountLinesResponse> GetAccountLines(XrplNetworkSettings networkSettings, AccountLinesRequest request, CancellationToken token);
 
     /// <summary>
     /// The account_objects command retrieves objectsrmation about an account, its activity, and its XRP balance.
@@ -39,7 +39,7 @@ public interface IXrplClient : IDisposable
     /// <exception cref="InvalidParametersException">One or more fields are specified incorrectly, or one or more required fields are missing.</exception>
     /// <exception cref="AccountNotFoundException">The address specified in the account field of the request does not correspond to an account in the ledger.</exception>
     /// <exception cref="LedgerNotFoundException">The ledger specified by the ledger_hash or ledger_index does not exist, or it does exist but the server does not have it.</exception>
-    Task<AccountObjectsResponse> GetAccountObjects(XrplProtocol protocol, AccountObjectsRequest request, CancellationToken token);
+    Task<AccountObjectsResponse> GetAccountObjects(XrplNetworkSettings networkSettings, AccountObjectsRequest request, CancellationToken token);
 
     /// <summary>
     /// The account_tx method retrieves a list of transactions that involved the specified account.
@@ -48,10 +48,10 @@ public interface IXrplClient : IDisposable
     /// <exception cref="InvalidParametersException">One or more fields are specified incorrectly, or one or more required fields are missing.</exception>
     /// <exception cref="AccountNotFoundException">The address specified in the account field of the request does not correspond to an account in the ledger.</exception>
     /// <exception cref="AccountMarkerMalformedException">If the marker field provided is not acceptable.</exception>
-    Task<AccountTxResponse> GetAccountTransactions(XrplProtocol protocol, AccountTxRequest request, CancellationToken token);
+    Task<AccountTxResponse> GetAccountTransactions(XrplNetworkSettings networkSettings, AccountTxRequest request, CancellationToken token);
 
 
-    Task<LedgerResponse> GetLedgerAsync(XrplProtocol protocol, LedgerRequest request, CancellationToken token);
+    Task<LedgerResponse> GetLedgerAsync(XrplNetworkSettings networkSettings, LedgerRequest request, CancellationToken token);
 
     /// <summary>
     /// The ledger_entry method returns a single ledger object from the XRP Ledger in its raw format.
@@ -62,12 +62,12 @@ public interface IXrplClient : IDisposable
     /// <exception cref="InvalidParametersException">One or more fields are specified incorrectly, or one or more required fields are missing.</exception>
     /// <exception cref="EntryNotFoundException">The requested ledger object does not exist in the ledger.</exception>
     /// <exception cref="LedgerNotFoundException">The ledger specified by the ledger_hash or ledger_index does not exist, or it does exist but the server does not have it.</exception>
-    Task<LedgerEntryResponse> GetLedgerEntryAsync(XrplProtocol protocol, LedgerEntryRequest request, CancellationToken token);
-    Task<FeeResponse> GetFeeAsync(XrplProtocol protocol, FeeRequest request, CancellationToken token);
-    Task<ServerDefinitionsResponse> GetServerDefinitionsAsync(XrplProtocol protocol, CancellationToken token);
-    Task<ServerStateResponse> GetServerStateAsync(XrplProtocol protocol, CancellationToken token);
-    Task<SubmitResponse> SubmitAsync(XrplProtocol protocol, SubmitRequest request, CancellationToken token);
-    Task<TransactionResponse> TransactionAsync(XrplProtocol protocol, TransactionRequest request, CancellationToken token);
+    Task<LedgerEntryResponse> GetLedgerEntryAsync(XrplNetworkSettings networkSettings, LedgerEntryRequest request, CancellationToken token);
+    Task<FeeResponse> GetFeeAsync(XrplNetworkSettings networkSettings, FeeRequest request, CancellationToken token);
+    Task<ServerDefinitionsResponse> GetServerDefinitionsAsync(XrplNetworkSettings networkSettings, CancellationToken token);
+    Task<ServerStateResponse> GetServerStateAsync(XrplNetworkSettings networkSettings, CancellationToken token);
+    Task<SubmitResponse> SubmitAsync(XrplNetworkSettings networkSettings, SubmitRequest request, CancellationToken token);
+    Task<TransactionResponse> TransactionAsync(XrplNetworkSettings networkSettings, TransactionRequest request, CancellationToken token);
 
-    Task SubscribeAsync(SubscribeRequest request, EventHandler<SubscriptionEventArgs> eventHandler, CancellationToken token);
+    Task SubscribeAsync(XrplWebSocketSettings webSocketSettings, SubscribeRequest request, EventHandler<SubscriptionEventArgs> eventHandler, CancellationToken token);
 }

--- a/src/XRPL.NET/XRPL.NET/Models/XrplNetworkSettings.cs
+++ b/src/XRPL.NET/XRPL.NET/Models/XrplNetworkSettings.cs
@@ -1,0 +1,20 @@
+﻿using XRPL.NET.Enums;
+
+namespace XRPL.NET.Models;
+
+public class XrplNetworkSettings
+{
+    public XrplNetworkSettings(string networkKey, XrplProtocol protocol, string? networkUrl = null)
+    {
+        NetworkKey = networkKey;
+        Protocol = protocol;
+        NetworkUrl = networkUrl;
+        ClientKey = $"{networkKey}-{protocol}";
+    }
+
+    public string NetworkKey { get; }
+    public XrplProtocol Protocol { get; }
+    public string? NetworkUrl { get; }
+
+    internal string ClientKey { get; }
+}

--- a/src/XRPL.NET/XRPL.NET/Models/XrplNetworkSettings.cs
+++ b/src/XRPL.NET/XRPL.NET/Models/XrplNetworkSettings.cs
@@ -4,17 +4,14 @@ namespace XRPL.NET.Models;
 
 public class XrplNetworkSettings
 {
-    public XrplNetworkSettings(string networkKey, XrplProtocol protocol, string? networkUrl = null)
+    public XrplNetworkSettings(int networkId, XrplProtocol protocol, string? networkUrl = null)
     {
-        NetworkKey = networkKey;
+        NetworkId = networkId;
         Protocol = protocol;
         NetworkUrl = networkUrl;
-        ClientKey = $"{networkKey}-{protocol}";
     }
 
-    public string NetworkKey { get; }
+    public int NetworkId { get; }
     public XrplProtocol Protocol { get; }
     public string? NetworkUrl { get; }
-
-    internal string ClientKey { get; }
 }

--- a/src/XRPL.NET/XRPL.NET/Models/XrplWebSocketSettings.cs
+++ b/src/XRPL.NET/XRPL.NET/Models/XrplWebSocketSettings.cs
@@ -4,7 +4,7 @@ namespace XRPL.NET.Models;
 
 public class XrplWebSocketSettings : XrplNetworkSettings
 {
-    public XrplWebSocketSettings(string networkKey, string? networkUrl = null) : base(networkKey, XrplProtocol.WebSocket, networkUrl)
+    public XrplWebSocketSettings(int networkId, string? networkUrl = null) : base(networkId, XrplProtocol.WebSocket, networkUrl)
     {
         
     }

--- a/src/XRPL.NET/XRPL.NET/Models/XrplWebSocketSettings.cs
+++ b/src/XRPL.NET/XRPL.NET/Models/XrplWebSocketSettings.cs
@@ -1,0 +1,11 @@
+﻿using XRPL.NET.Enums;
+
+namespace XRPL.NET.Models;
+
+public class XrplWebSocketSettings : XrplNetworkSettings
+{
+    public XrplWebSocketSettings(string networkKey, string? networkUrl = null) : base(networkKey, XrplProtocol.WebSocket, networkUrl)
+    {
+        
+    }
+}

--- a/src/XRPL.NET/XRPL.NET/XrplClient.cs
+++ b/src/XRPL.NET/XRPL.NET/XrplClient.cs
@@ -322,7 +322,8 @@ public class XrplClient : IXrplClient
 
     private IXrplProtocolClient GetClient(XrplNetworkSettings networkSettings)
     {
-        if (!_clients.TryGetValue(networkSettings.ClientKey, out var client))
+        var clientKey = $"{networkSettings.NetworkId}-{networkSettings.Protocol}";
+        if (!_clients.TryGetValue(clientKey, out var client))
         {
             var networkUrl = GetNetworkUrl(networkSettings);
             client = networkSettings.Protocol switch
@@ -332,7 +333,7 @@ public class XrplClient : IXrplClient
                 _ => throw new ArgumentOutOfRangeException(nameof(networkSettings), networkSettings.Protocol, $"Unknown XRPL protocol: {networkSettings.Protocol}")
             };
 
-            _clients.TryAdd(networkSettings.ClientKey, client);
+            _clients.TryAdd(clientKey, client);
         }
 
         return client;
@@ -340,12 +341,12 @@ public class XrplClient : IXrplClient
 
     private string GetNetworkUrl(XrplNetworkSettings networkSettings)
     {
-        var networkUrl = _config.GetNetworkUrl(networkSettings.NetworkKey, networkSettings.Protocol);
+        var networkUrl = _config.GetNetworkUrl(networkSettings.NetworkId, networkSettings.Protocol);
         networkUrl ??= networkSettings.NetworkUrl;
 
         if (string.IsNullOrWhiteSpace(networkUrl))
         {
-            throw new InvalidOperationException($"Missing {networkSettings.Protocol} URI of network with Key: {networkSettings.NetworkKey}");
+            throw new InvalidOperationException($"Missing {networkSettings.Protocol} URI of network with Key: {networkSettings.NetworkId}");
         }
 
         return networkUrl;

--- a/src/XRPL.NET/XRPL.NET/XrplClient.cs
+++ b/src/XRPL.NET/XRPL.NET/XrplClient.cs
@@ -8,6 +8,7 @@ using XRPL.NET.Enums;
 using XRPL.NET.EventArgs;
 using XRPL.NET.Exceptions;
 using XRPL.NET.Helpers;
+using XRPL.NET.Models;
 using XRPL.NET.Models.Methods.Accounts;
 using XRPL.NET.Models.Methods.Ledger;
 using XRPL.NET.Models.Methods.ServerInfo;
@@ -25,7 +26,7 @@ public class XrplClient : IXrplClient
     private readonly ILogger<XrplClient> _logger;
 
     private readonly CancellationTokenSource _cancellationTokenSource = new();
-    private readonly ConcurrentDictionary<XrplProtocol, IXrplProtocolClient> _clients = new();
+    private readonly ConcurrentDictionary<string, IXrplProtocolClient> _clients = new();
 
     public XrplClient(
         IOptions<XrplClientConfig> options,
@@ -38,11 +39,11 @@ public class XrplClient : IXrplClient
     #region Account Methods
 
     /// <inheritdoc />
-    public async Task<AccountInfoResponse> GetAccountInfo(XrplProtocol protocol, AccountInfoRequest request, CancellationToken token)
+    public async Task<AccountInfoResponse> GetAccountInfo(XrplNetworkSettings networkSettings, AccountInfoRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<AccountInfoResponse>(protocol, "account_info", request, token);
+            return await GetResponseAsync<AccountInfoResponse>(networkSettings, "account_info", request, token);
         }
         catch (XrplException ex)
         {
@@ -63,11 +64,11 @@ public class XrplClient : IXrplClient
     }
 
     /// <inheritdoc />
-    public async Task<AccountLinesResponse> GetAccountLines(XrplProtocol protocol, AccountLinesRequest request, CancellationToken token)
+    public async Task<AccountLinesResponse> GetAccountLines(XrplNetworkSettings networkSettings, AccountLinesRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<AccountLinesResponse>(protocol, "account_lines", request, token);
+            return await GetResponseAsync<AccountLinesResponse>(networkSettings, "account_lines", request, token);
         }
         catch (XrplException ex)
         {
@@ -90,11 +91,11 @@ public class XrplClient : IXrplClient
     }
 
     /// <inheritdoc />
-    public async Task<AccountObjectsResponse> GetAccountObjects(XrplProtocol protocol, AccountObjectsRequest request, CancellationToken token)
+    public async Task<AccountObjectsResponse> GetAccountObjects(XrplNetworkSettings networkSettings, AccountObjectsRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<AccountObjectsResponse>(protocol, "account_objects", request, token);
+            return await GetResponseAsync<AccountObjectsResponse>(networkSettings, "account_objects", request, token);
         }
         catch (XrplException ex)
         {
@@ -115,11 +116,11 @@ public class XrplClient : IXrplClient
     }
 
     /// <inheritdoc />
-    public async Task<AccountTxResponse> GetAccountTransactions(XrplProtocol protocol, AccountTxRequest request, CancellationToken token)
+    public async Task<AccountTxResponse> GetAccountTransactions(XrplNetworkSettings networkSettings, AccountTxRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<AccountTxResponse>(protocol, "account_tx", request, token);
+            return await GetResponseAsync<AccountTxResponse>(networkSettings, "account_tx", request, token);
         }
         catch (XrplException ex)
         {
@@ -144,11 +145,11 @@ public class XrplClient : IXrplClient
     #region Ledger Methods
 
     /// <inheritdoc />
-    public async Task<LedgerResponse> GetLedgerAsync(XrplProtocol protocol, LedgerRequest request, CancellationToken token)
+    public async Task<LedgerResponse> GetLedgerAsync(XrplNetworkSettings networkSettings, LedgerRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<LedgerResponse>(protocol, "ledger", request, token);
+            return await GetResponseAsync<LedgerResponse>(networkSettings, "ledger", request, token);
         }
         catch (XrplException ex)
         {
@@ -160,11 +161,11 @@ public class XrplClient : IXrplClient
     }
 
     /// <inheritdoc />
-    public async Task<LedgerEntryResponse> GetLedgerEntryAsync(XrplProtocol protocol, LedgerEntryRequest request, CancellationToken token)
+    public async Task<LedgerEntryResponse> GetLedgerEntryAsync(XrplNetworkSettings networkSettings, LedgerEntryRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<LedgerEntryResponse>(protocol, "ledger_entry", request, token);
+            return await GetResponseAsync<LedgerEntryResponse>(networkSettings, "ledger_entry", request, token);
         }
         catch (XrplException ex)
         {
@@ -189,11 +190,11 @@ public class XrplClient : IXrplClient
 
     #region Transaction Methods
 
-    public async Task<SubmitResponse> SubmitAsync(XrplProtocol protocol, SubmitRequest request, CancellationToken token)
+    public async Task<SubmitResponse> SubmitAsync(XrplNetworkSettings networkSettings, SubmitRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<SubmitResponse>(protocol, "submit", request, token);
+            return await GetResponseAsync<SubmitResponse>(networkSettings, "submit", request, token);
         }
         catch (XrplException ex)
         {
@@ -204,11 +205,11 @@ public class XrplClient : IXrplClient
         }
     }
 
-    public async Task<TransactionResponse> TransactionAsync(XrplProtocol protocol, TransactionRequest request, CancellationToken token)
+    public async Task<TransactionResponse> TransactionAsync(XrplNetworkSettings networkSettings, TransactionRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<TransactionResponse>(protocol, "tx", request, token);
+            return await GetResponseAsync<TransactionResponse>(networkSettings, "tx", request, token);
         }
         catch (XrplException ex)
         {
@@ -223,11 +224,11 @@ public class XrplClient : IXrplClient
 
     #region Server Info Methods
 
-    public async Task<FeeResponse> GetFeeAsync(XrplProtocol protocol, FeeRequest request, CancellationToken token)
+    public async Task<FeeResponse> GetFeeAsync(XrplNetworkSettings networkSettings, FeeRequest request, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<FeeResponse>(protocol, "fee", request, token);
+            return await GetResponseAsync<FeeResponse>(networkSettings, "fee", request, token);
         }
         catch (XrplException ex)
         {
@@ -238,11 +239,11 @@ public class XrplClient : IXrplClient
         }
     }
 
-    public async Task<ServerDefinitionsResponse> GetServerDefinitionsAsync(XrplProtocol protocol, CancellationToken token)
+    public async Task<ServerDefinitionsResponse> GetServerDefinitionsAsync(XrplNetworkSettings networkSettings, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<ServerDefinitionsResponse>(protocol, "server_definitions", default, token, new JsonSerializerOptions
+            return await GetResponseAsync<ServerDefinitionsResponse>(networkSettings, "server_definitions", default, token, new JsonSerializerOptions
             {
                 Converters = { new FieldElementConverter() }
             });
@@ -256,11 +257,11 @@ public class XrplClient : IXrplClient
         }
     }
 
-    public async Task<ServerStateResponse> GetServerStateAsync(XrplProtocol protocol, CancellationToken token)
+    public async Task<ServerStateResponse> GetServerStateAsync(XrplNetworkSettings networkSettings, CancellationToken token)
     {
         try
         {
-            return await GetResponseAsync<ServerStateResponse>(protocol, "server_state", default, token);
+            return await GetResponseAsync<ServerStateResponse>(networkSettings, "server_state", default, token);
         }
         catch (XrplException ex)
         {
@@ -275,12 +276,13 @@ public class XrplClient : IXrplClient
 
     #region Subscription Methods
 
-    public async Task SubscribeAsync(SubscribeRequest request, EventHandler<SubscriptionEventArgs> eventHandler, CancellationToken token)
+    public async Task SubscribeAsync(XrplWebSocketSettings webSocketSettings, SubscribeRequest request, EventHandler<SubscriptionEventArgs> eventHandler, CancellationToken token)
     {
         try
         {
             var linked = GetLinkedCancellationToken(token);
-            using var client = new WebSocketListenerClient(_config.WebSocketUri, _cancellationTokenSource, _logger);
+            var networkUrl = GetNetworkUrl(webSocketSettings);
+            using var client = new WebSocketListenerClient(new Uri(networkUrl), _cancellationTokenSource, _logger);
             await foreach (var message in client.GetResponses("subscribe", request, linked).WithCancellation(linked))
             {
                 eventHandler(this,
@@ -309,31 +311,44 @@ public class XrplClient : IXrplClient
         return source.Token;
     }
 
-    private async Task<T> GetResponseAsync<T>(XrplProtocol protocol, string command, object? request, CancellationToken? token, JsonSerializerOptions? options = null) where T : class
+    private async Task<T> GetResponseAsync<T>(XrplNetworkSettings networkSettings, string command, object? request, CancellationToken? token, JsonSerializerOptions? options = null) where T : class
     {
-        var client = GetClient(protocol);
+        var client = GetClient(networkSettings);
         var linked = GetLinkedCancellationToken(token);
         options ??= XrplJsonHelper.SerializerOptions;
 
         return await client.GetResponse<T>(command, request, options, linked);
     }
 
-    private IXrplProtocolClient GetClient(XrplProtocol protocol)
+    private IXrplProtocolClient GetClient(XrplNetworkSettings networkSettings)
     {
-        if (!_clients.TryGetValue(protocol, out var client))
+        if (!_clients.TryGetValue(networkSettings.ClientKey, out var client))
         {
-            // TODO: Config URL validations
-            client = protocol switch
+            var networkUrl = GetNetworkUrl(networkSettings);
+            client = networkSettings.Protocol switch
             {
-                XrplProtocol.JsonRpc => new JsonRpcClient(_config.JsonRpcUri, _logger),
-                XrplProtocol.WebSocket => new WebSocketClient(_config.WebSocketUri, _cancellationTokenSource, _logger),
-                _ => throw new ArgumentOutOfRangeException(nameof(protocol), protocol, $"Unknown XRPL protocol: {protocol}")
+                XrplProtocol.JsonRpc => new JsonRpcClient(new Uri(networkUrl), _logger),
+                XrplProtocol.WebSocket => new WebSocketClient(new Uri(networkUrl), _cancellationTokenSource, _logger),
+                _ => throw new ArgumentOutOfRangeException(nameof(networkSettings), networkSettings.Protocol, $"Unknown XRPL protocol: {networkSettings.Protocol}")
             };
 
-            _clients.TryAdd(protocol, client);
+            _clients.TryAdd(networkSettings.ClientKey, client);
         }
 
         return client;
+    }
+
+    private string GetNetworkUrl(XrplNetworkSettings networkSettings)
+    {
+        var networkUrl = _config.GetNetworkUrl(networkSettings.NetworkKey, networkSettings.Protocol);
+        networkUrl ??= networkSettings.NetworkUrl;
+
+        if (string.IsNullOrWhiteSpace(networkUrl))
+        {
+            throw new InvalidOperationException($"Missing {networkSettings.Protocol} URI of network with Key: {networkSettings.NetworkKey}");
+        }
+
+        return networkUrl;
     }
 
     public void Dispose()


### PR DESCRIPTION
`XrplClient` can now support multiple networks by the unique XRPL `NetworkID` as identifier.