### PR TITLE
Request account_namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An account in the XRP Ledger represents a holder of XRP and a sender of transact
 |   | account_currencies | Get a list of currencies an account can send or receive.                                          |
 |✅| account_info       | Get basic data about an account.                                                                  |
 |✅| account_lines      | Get info about an account's trust lines.                                                          |
+|✅| account_namespace    | Get the Hook State Objects on a particular account in a particular namespace.                  |
 |   | account_nfts       | Get a list of all NFTs for an account.                                                            |
 |✅| account_objects    | Get all ledger objects owned by an account.                                                       |
 |   | account_offers     | Get info about an account's currency exchange offers.                                            |

--- a/src/XRPL.NET/XRPL.NET/IXrplClient.cs
+++ b/src/XRPL.NET/XRPL.NET/IXrplClient.cs
@@ -32,8 +32,17 @@ public interface IXrplClient : IDisposable
     Task<AccountLinesResponse> GetAccountLines(XrplNetworkSettings networkSettings, AccountLinesRequest request, CancellationToken token);
 
     /// <summary>
-    /// The account_objects command retrieves objectsrmation about an account, its activity, and its XRP balance.
-    /// All objectsrmation retrieved is relative to a particular version of the ledger.
+    /// Use the account_namespace websocket API to query the Hook State Objects on a particular account in a particular namespace.
+    /// </summary>
+    /// <param name="token">The <see cref="CancellationToken">CancellationToken</see> to observe.</param>
+    /// <exception cref="InvalidParametersException">One or more fields are specified incorrectly, or one or more required fields are missing.</exception>
+    /// <exception cref="AccountNotFoundException">The address specified in the account field of the request does not correspond to an account in the ledger.</exception>
+    /// <exception cref="LedgerNotFoundException">The ledger specified by the ledger_hash or ledger_index does not exist, or it does exist but the server does not have it.</exception>
+    Task<AccountNamespaceResponse> GetAccountNamespace(XrplNetworkSettings networkSettings, AccountNamespaceRequest request, CancellationToken token);
+
+    /// <summary>
+    /// The account_objects command retrieves objects information about an account, its activity, and its XRP balance.
+    /// All objects information retrieved is relative to a particular version of the ledger.
     /// </summary>
     /// <param name="token">The <see cref="CancellationToken">CancellationToken</see> to observe.</param>
     /// <exception cref="InvalidParametersException">One or more fields are specified incorrectly, or one or more required fields are missing.</exception>

--- a/src/XRPL.NET/XRPL.NET/Models/Methods/Accounts/AccountNamespaceRequest.cs
+++ b/src/XRPL.NET/XRPL.NET/Models/Methods/Accounts/AccountNamespaceRequest.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace XRPL.NET.Models.Methods.Accounts;
+
+public class AccountNamespaceRequest : LedgerRequestBase, IPaginationMarker
+{
+    /// <summary>
+    /// A unique identifier for the account, most commonly the account's <see href="https://xrpl.org/basic-data-types.html#addresses">xAddress</see>.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("account")]
+    public string Account { get; set; } = default!;
+
+    [JsonPropertyName("namespace_id")]
+    public string NamespaceId { get; set; } = default!;
+
+    /// <summary>
+    /// The maximum number of objects to include in the results.
+    /// Must be within the inclusive range 10 to 400 on non-admin connections. The default is 200.
+    /// </summary>
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+
+    /// <summary>
+    /// Value from a previous paginated response.
+    /// Resume retrieving data where that response left off.
+    /// </summary>
+    [JsonPropertyName("marker")]
+    public object? Marker { get; set; }
+}

--- a/src/XRPL.NET/XRPL.NET/Models/Methods/Accounts/AccountNamespaceResponse.cs
+++ b/src/XRPL.NET/XRPL.NET/Models/Methods/Accounts/AccountNamespaceResponse.cs
@@ -1,0 +1,55 @@
+﻿using System.Text.Json.Serialization;
+using XRPL.NET.Models.LedgerObjectTypes;
+
+namespace XRPL.NET.Models.Methods.Accounts;
+
+public class AccountNamespaceResponse : IPaginationMarker
+{
+    /// <summary>
+    /// Unique <see href="https://xrpl.org/basic-data-types.html#addresses">Address</see> of the account this request corresponds to
+    /// </summary>
+    [JsonPropertyName("account")]
+    public string Account { get; set; } = default!;
+
+    [JsonPropertyName("namespace_entries")]
+    public List<HookState> NamespaceEntries { get; set; } = default!;
+
+    /// <summary>
+    /// (Omitted if <see cref="LedgerHash"/> or <see cref="LedgerIndex"/> provided) The ledger index of the current open ledger, which was used when retrieving this information.
+    /// </summary>
+    [JsonPropertyName("ledger_current_index")]
+    public uint? LedgerCurrentIndex { get; set; }
+
+    /// <summary>
+    /// (May be omitted) The ledger index of the ledger version that was used to generate this response.
+    /// </summary>
+    [JsonPropertyName("ledger_index")]
+    public uint? LedgerIndex { get; set; }
+
+    /// <summary>
+    /// (May be omitted) The identifying hash of the ledger that was used to generate this response.
+    /// </summary>
+    [JsonPropertyName("ledger_hash")]
+    public string? LedgerHash { get; set; }
+
+    [JsonPropertyName("namespace_id")]
+    public string? NamespaceId { get; set; }
+
+    /// <summary>
+    /// (May be omitted) The limit that was used in this request, if any.
+    /// </summary>
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+
+    /// <summary>
+    /// Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one.
+    /// </summary>
+    [JsonPropertyName("marker")]
+    public object? Marker { get; set; }
+
+    /// <summary>
+    /// If included and set to true, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change.
+    /// </summary>
+    [JsonPropertyName("validated")]
+    public bool? Validated { get; set; }
+}

--- a/src/XRPL.NET/XRPL.NET/XrplClient.cs
+++ b/src/XRPL.NET/XRPL.NET/XrplClient.cs
@@ -91,6 +91,31 @@ public class XrplClient : IXrplClient
     }
 
     /// <inheritdoc />
+    public async Task<AccountNamespaceResponse> GetAccountNamespace(XrplNetworkSettings networkSettings, AccountNamespaceRequest request, CancellationToken token)
+    {
+        try
+        {
+            return await GetResponseAsync<AccountNamespaceResponse>(networkSettings, "account_namespace", request, token);
+        }
+        catch (XrplException ex)
+        {
+            _logger.LogTrace(ex, "Failed to retrieve account namespace with request {@Request}.", request);
+
+            switch (ex.Error)
+            {
+                case "invalidParams":
+                    throw new InvalidParametersException(ex);
+                case "actNotFound":
+                    throw new AccountNotFoundException(request.Account, ex);
+                case "lgrNotFound":
+                    throw new LedgerNotFoundException(request.Ledger!, ex);
+                default:
+                    throw;
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<AccountObjectsResponse> GetAccountObjects(XrplNetworkSettings networkSettings, AccountObjectsRequest request, CancellationToken token)
     {
         try


### PR DESCRIPTION
Use the `account_namespace` to query the Hook State Objects on a particular account in a particular namespace.